### PR TITLE
try add slugID

### DIFF
--- a/apps/art-scan/src/components/collection/item.ts
+++ b/apps/art-scan/src/components/collection/item.ts
@@ -46,11 +46,11 @@ export class CollectionDetail extends TailwindElement(style) {
   get tokenID() {
     return this.token?.tokenID ?? ''
   }
-  get sequence() {
-    return this.token?.sequence ?? ''
-  }
   get slugName() {
     return this.token?.slugName ?? ''
+  }
+  get slugID() {
+    return this.token?.slugID ?? ''
   }
   get address() {
     return this.item.address

--- a/apps/art-scan/src/components/collection/list-item.ts
+++ b/apps/art-scan/src/components/collection/list-item.ts
@@ -32,8 +32,8 @@ export class CollectionList extends LazyElement(TailwindElement(style)) {
     return this.item.ctime ? new Date(this.item.ctime).toLocaleString() : ''
   }
   get token() {
-    const { tokenID, sequence } = this.item
-    return { name: this.meta?.name, tokenID, sequence }
+    const { tokenID, slugID } = this.item
+    return { name: this.meta?.name, tokenID, slugID }
   }
   get cookedName() {
     return this.cooked?.parsed?.val
@@ -67,7 +67,7 @@ export class CollectionList extends LazyElement(TailwindElement(style)) {
     return html`<div class="item p-4">
       <div class="font-medium">
         <loading-skeleton .expect=${this.tokenName}
-          ><dui-link class="uri" href=${`/collection/${this.cookedUri}`}>${this.tokenName}</dui-link></loading-skeleton
+          ><dui-link class="uri" href=${`/collection/${this.cookedUri}`}>${this.cookedUri}</dui-link></loading-skeleton
         >
       </div>
       <div class="flex gap-4 py-4">

--- a/apps/art-scan/src/lib/collection.ts
+++ b/apps/art-scan/src/lib/collection.ts
@@ -6,6 +6,7 @@ export const cookToken = (token: Record<string, any>): NFTToken => {
   return {
     address,
     tokenID,
+    slugID: tokenID,
     ctime: token.createdAt * 1000,
     tokenURI
   }

--- a/apps/art-scan/src/lib/types.d.ts
+++ b/apps/art-scan/src/lib/types.d.ts
@@ -11,5 +11,4 @@ declare type CollOptions = {
   minter?: string
   slugName?: string
   tokenID?: string
-  sequence?: string
 }

--- a/packages/core/src/uri.ts
+++ b/packages/core/src/uri.ts
@@ -2,7 +2,13 @@ import safeDecodeURIComponent from 'safe-decode-uri-component'
 export { safeDecodeURIComponent }
 
 // Just encode reserved characters
-export const safeEncodeURIComponent = (s: string) => s.replaceAll(/[;/?:@&=+$,#]/g, (r) => encodeURIComponent(r))
+export const safeEncodeURIComponent = (s: string) =>
+  s
+    .toLowerCase()
+    .replace(/<(?:.|\n)*?>/gm, '') // Drop HTML tags
+    .replace(/[$\-_.+!*'(), "<>#%{}|^~[\]` ;/?:@=&]/g, ' ') // Drop special, unsafe and reserved characters
+    .trim()
+    .replace(/\s+/g, '-')
 
 export const normalizeUri = (uri = '') => {
   if (/^(ipfs):/.test(uri)) return `https://ipfs.io/ipfs/${uri.replace(/^(ipfs):\/\//, '')}`

--- a/packages/ethers/src/DOIDParser/index.ts
+++ b/packages/ethers/src/DOIDParser/index.ts
@@ -9,7 +9,15 @@ const cookeDOID = async (DOIDName: string, token: NFTToken, decoded: string): Pr
   let { error, msg, name, doid } = DOID
   // Cook
   const cooked: DOIDObject = { DOID, name, doid, token, error, msg }
-  token.slugName = slugify(token.name ?? '')
+  let result = /^(.*?)[ #](\d*)$/.exec(token.name ?? '')
+  if (result) {
+    token.slugName = safeEncodeURIComponent(result[1])
+    if (result[2] != token.tokenID) {
+      token.slugID = result[2].replace(/^0*/, '')
+    }
+  } else {
+    token.slugName = safeEncodeURIComponent(token.name ?? '')
+  }
   const val = stringify(cooked)
   const equal = decoded === val
   if (equal && name) token.minter = await reverseDOIDName(name)
@@ -26,11 +34,11 @@ export const parseFromString = async (src = ''): Promise<DOIDObject> => {
   const decoded = safeDecodeURIComponent(src)
   const [, DOIDName, , tokenish = ''] = decoded.match(/^([^\/]+?)(\/(.+)?)?$/) ?? []
   // Token
-  const [, tokenName = '', , tokenID = '', , sequence = ''] = tokenish.match(/^(.+?)(#(\d+?)(-(\d+)?)?)?$/) ?? []
+  const [, tokenName = '', , slugID = '', , tokenID = ''] = tokenish.match(/^(.+?)(#(\d+?)(-(\d+)?)?)?$/) ?? []
   const token: NFTToken = {
     name: tokenName,
-    tokenID,
-    sequence
+    slugID,
+    tokenID: tokenID.length == 0 ? slugID : tokenID
   }
   return await cookeDOID(DOIDName, token, decoded)
 }
@@ -46,20 +54,20 @@ export const stringify = (doidObject: DOIDObject, { keepIdentifier = false, enco
   let { name, token } = doidObject
   if (!name) return ''
   name = wrapTLD(name)
-  let { name: tokenName = '', tokenID = '', sequence = '' } = token ?? {}
+  let { slugName: tokenName = '', tokenID = '', slugID = '' } = token ?? {}
   if (encode) {
     tokenName = safeEncodeURIComponent(tokenName)
   }
-  sequence = sequence ? `-${sequence}` : tokenID && keepIdentifier ? '-' : ''
-  tokenID = tokenID ? `#${tokenID}` : tokenName && keepIdentifier ? '#' : ''
+  tokenID = tokenID && tokenID != slugID ? `-${tokenID}` : tokenID && keepIdentifier ? '-' : ''
+  slugID = slugID ? `#${slugID}` : tokenName && keepIdentifier ? '#' : ''
   tokenName = tokenName ? `/${tokenName}` : name && keepIdentifier ? '/' : ''
-  return `${name}${tokenName}${tokenID}${sequence}`
+  return `${name}${tokenName}${slugID}${tokenID}`
 }
 
 export const parseFromColl = async (coll: any): Promise<DOIDObject> => {
   const DOIDName = coll.name ?? coll.DOIDName
   const decoded = safeDecodeURIComponent(DOIDName)
-  const token = coll.token ?? { name: coll.tokenName, tokenID: coll.tokenID, sequence: coll.sequence }
+  const token = coll.token ?? { name: coll.tokenName, tokenID: coll.tokenID, slugID: coll.slugID }
   return await cookeDOID(DOIDName, token, decoded)
 }
 

--- a/packages/ethers/src/DOIDParser/types.d.ts
+++ b/packages/ethers/src/DOIDParser/types.d.ts
@@ -8,7 +8,6 @@ declare interface DOIDObject extends CheckedName {
   address?: string
   token?: NFTToken
   tokenID?: string
-  sequence?: string
   error?: boolean
   msg?: string
   equal?: boolean

--- a/packages/ethers/src/types.d.ts
+++ b/packages/ethers/src/types.d.ts
@@ -22,6 +22,7 @@ declare interface NFTToken {
   tokenID?: TokenID
   name?: string
   slugName?: string
+  slugID?: string
   uri?: string // ERC1155 asis ERC721 tokenURI
   tokenURI?: string
   block?: number
@@ -36,7 +37,6 @@ declare interface NFTToken {
   txHash?: Address
   txs?: NFTTokenTxs
   seq?: string
-  sequence?: string
   approved?: boolean
 }
 declare interface Token {

--- a/packages/tests/test/ethers/nameParser.test.ts
+++ b/packages/tests/test/ethers/nameParser.test.ts
@@ -16,6 +16,8 @@ describe('DOIDParser', async () => {
     var req = 'banana.doid/crypto-name#1-2'
     var parser = await DOIDParser(req)
     expect(parser.parsed.name).to.equal('banana')
+    expect(parser.parsed.token?.slugID).to.equal('1')
+    expect(parser.parsed.token?.tokenID).to.equal('2')
     // collection name
     expect(parser.stringify()).to.equal(req)
     var parser = await DOIDParser(`banana.doid/你好-世/界 %%2E的#`)
@@ -25,22 +27,29 @@ describe('DOIDParser', async () => {
   it('with multi slash', async () => {
     var parser = await DOIDParser('banana.doid/crypto-name/eth#1-2')
     expect(parser.parsed.token?.name).to.equal('crypto-name/eth')
-    expect(parser.parsed.uri).to.equal('banana.doid/crypto-name%2Feth#1-2')
+    expect(parser.parsed.token?.slugID).to.equal('1')
+    expect(parser.parsed.token?.tokenID).to.equal('2')
+    expect(parser.parsed.uri).to.equal('banana.doid/crypto-name-eth#1-2')
   })
 
   it('with multi hash', async () => {
     var parser = await DOIDParser('banana.doid/crypto-name/eth#abc#1-')
     expect(parser.parsed.token?.name).to.equal('crypto-name/eth#abc')
+    expect(parser.parsed.token?.slugID).to.equal('1')
     expect(parser.parsed.token?.tokenID).to.equal('1')
-    expect(parser.parsed.token?.sequence).to.equal('')
     var parser = await DOIDParser('banana.doid/crypto-name/eth#abc###')
     expect(parser.parsed.token?.name).to.equal('crypto-name/eth#abc###')
   })
 
   it('token', async () => {
-    var parser = await DOIDParser('banana.doid/crypto-name#1-2')
+    var parser = await DOIDParser('banana.doid/crypto-name#1')
+    expect(parser.parsed.token?.slugID).to.equal('1')
     expect(parser.parsed.token?.tokenID).to.equal('1')
-    expect(parser.parsed.token?.sequence).to.equal('2')
+    expect(parser.parsed.uri).to.equal('banana.doid/crypto-name#1')
+    var parser = await DOIDParser('banana.doid/crypto-name#1-2')
+    expect(parser.parsed.token?.slugID).to.equal('1')
+    expect(parser.parsed.token?.tokenID).to.equal('2')
+    expect(parser.parsed.uri).to.equal('banana.doid/crypto-name#1-2')
     var parser = await DOIDParser('banana.doid/crypto-name##')
     expect(parser.parsed.token?.tokenID).to.equal('')
   })
@@ -52,7 +61,7 @@ describe('DOIDParser', async () => {
 
   it('encode tokenName for uri', async () => {
     var parser = await DOIDParser('vincent/The Starry Night/abc')
-    expect(parser.parsed.uri).to.equal('vincent.doid/The Starry Night%2Fabc')
-    expect(parser.parsed.val).to.equal('vincent.doid/The Starry Night/abc')
+    expect(parser.parsed.uri).to.equal('vincent.doid/the-starry-night-abc')
+    expect(parser.parsed.val).to.equal('vincent.doid/the-starry-night-abc')
   })
 })


### PR DESCRIPTION
This is an update that adds slugID, which is same to tokenID by default.

`slugName` and `slugID` are extracted from name fetched from tokenURI with regex `/^(.*?)[ #](\d*)$/`. If `slugID` is empty, then fallback to tokenID.

In this case, token doid id is formed as `banana.doid/slugName#slugID-tokenID`, where `-tokenID` is optional when tokenID is same as slugID (`banana.doid/slugName#slugID`).